### PR TITLE
Fix line number positioning

### DIFF
--- a/src/MyDrawing.hs
+++ b/src/MyDrawing.hs
@@ -88,7 +88,7 @@ drawTextSyntaxed renderer style syntaxTree syntaxMap textLines = do
       let oy = ty
       let hy = by - asc * 0.35
 
-      let x2 = maybe 50 _glpXMin (S.lookup (pred startColumn) _tlGlyphs)
+      let x2 = maybe 50 _glpX (S.lookup (pred startColumn) _tlGlyphs)
 
       let text = _tlText
       let textPart

--- a/src/MyTextArea.hs
+++ b/src/MyTextArea.hs
@@ -800,7 +800,6 @@ makeTextArea !wdata !config !state = widget where
     let wvp = fromMaybe (wenv ^. L.viewport) (removeOuterBounds style (wenv ^. L.viewport))
     let textLine idx = do
           -- Do not use viewport's x here; just set the desired padding values
-          --let rect' = def & L.x .~ 5 & L.y .~ y & L.w .~ 20 & L.h .~ 20
           let rect2 = textLines ^?! ix (idx - 1) . L.rect
           def
             & L.text .~ T.pack (show idx)
@@ -828,7 +827,6 @@ makeTextArea !wdata !config !state = widget where
           -- Apply x offset here
           -- Modified. Also apply y offset here. It uses the node's viewport
           -- (without subtracting padding, as contentArea does)
-          -- drawInTranslation renderer (Point (wvp ^. L.x) 0) $
           drawInTranslation renderer (Point (wvp ^. L.x) (contentArea ^. L.y + descending)) $
           --drawInTranslation renderer (Point (wvp ^. L.x) (3 + node ^. L.info . L.viewport . L.y)) $
             mapM_ renderLineNumber [1..length textLines]

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,7 +45,7 @@ extra-deps:
 #- git: https://github.com/fjvallarino/monomer
 #  commit: a7f9fd904f5a9094733d5f209c79d8acef029916
 - git: https://github.com/fjvallarino/monomer
-  commit: b80e2ca0360b5d740c9e1e9e8a07e00457744f6b
+  commit: 418d6ddc697118fc727628e1c5b2f41114c53689
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,7 +45,7 @@ extra-deps:
 #- git: https://github.com/fjvallarino/monomer
 #  commit: a7f9fd904f5a9094733d5f209c79d8acef029916
 - git: https://github.com/fjvallarino/monomer
-  commit: 418d6ddc697118fc727628e1c5b2f41114c53689
+  commit: 574c08ac9aa1253a9e0e5ec91e7b72a881816273
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -16,12 +16,12 @@ packages:
     version: 1.3.0.0
     git: https://github.com/fjvallarino/monomer
     pantry-tree:
-      size: 17322
-      sha256: 67ee3a25909c21e5cba4f41428613d7929e4b21e9ba8ad0ebf7a5677d6913bf4
-    commit: b80e2ca0360b5d740c9e1e9e8a07e00457744f6b
+      size: 17325
+      sha256: a90c767ecba0ff4e1322fbf681864ea4a11cc90dd91a87dd17b01b2297970bf4
+    commit: 418d6ddc697118fc727628e1c5b2f41114c53689
   original:
     git: https://github.com/fjvallarino/monomer
-    commit: b80e2ca0360b5d740c9e1e9e8a07e00457744f6b
+    commit: 418d6ddc697118fc727628e1c5b2f41114c53689
 snapshots:
 - completed:
     size: 590102

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -17,11 +17,11 @@ packages:
     git: https://github.com/fjvallarino/monomer
     pantry-tree:
       size: 17325
-      sha256: a90c767ecba0ff4e1322fbf681864ea4a11cc90dd91a87dd17b01b2297970bf4
-    commit: 418d6ddc697118fc727628e1c5b2f41114c53689
+      sha256: 51e2190bfdb45c971f6eef1f4d1d703153fdccf7245622676084537a634a7d0c
+    commit: 574c08ac9aa1253a9e0e5ec91e7b72a881816273
   original:
     git: https://github.com/fjvallarino/monomer
-    commit: 418d6ddc697118fc727628e1c5b2f41114c53689
+    commit: 574c08ac9aa1253a9e0e5ec91e7b72a881816273
 snapshots:
 - completed:
     size: 590102


### PR DESCRIPTION
This PR uses a recent Monomer update that fixes, without workarounds, the issue with glyph positions differing between calculations and rendering. The update also includes a new attribute in `GlyphPos`, called `x`, that should be used when rendering glyphs manually; the `minX` attribute should not be used for rendering, only for calculating bounding boxes.

The difference in line number position is caused by the descending of the font not being considered.

~Note: the commit hash will no longer be valid after the [PR](https://github.com/fjvallarino/monomer/pull/125) is merged.~
Note: the commit hash now points to main; the is no need to update it.
